### PR TITLE
Update SecOps-DNS-Public

### DIFF
--- a/SecOps-DNS-Public
+++ b/SecOps-DNS-Public
@@ -1,3 +1,5 @@
+cp.envisionfonddulac.biz
+envisionfonddulac.biz
 zutebo.com
 searchya.com
 iwatchfriends.cc


### PR DESCRIPTION
The domain cp.envisionfonddulac.biz is listed in the ThreatFox IOC database as a payload delivery domain associated with FakeUpdate / GhoLoader, with 100% confidence