### PR TITLE
Update SecOps-URL-List

### DIFF
--- a/SecOps-URL-List
+++ b/SecOps-URL-List
@@ -1,3 +1,5 @@
+cp.envisionfonddulac.biz
+envisionfonddulac.biz
 www.searchya.com
 https://zutebo.com
 enscentroamerica.com


### PR DESCRIPTION
The domain cp.envisionfonddulac.biz is listed in the ThreatFox IOC database as a payload delivery domain associated with FakeUpdate / GhoLoader, with 100% confidence