### PR TITLE
Update SecOps-DNS-Public

### DIFF
--- a/SecOps-DNS-Public
+++ b/SecOps-DNS-Public
@@ -633,7 +633,6 @@ directfilesjo.com
 jofilesjo.com
 ieh92qspgy.com
 bouhoagy.net
-prebid.a-mo.net
 depressively.net
 ws.onehub.com
 fatdoggish.net


### PR DESCRIPTION
הסרתי את prebid.a-mo.net
מדובר בדומיין שקשור לפרסום והוא מקפיץ הרבה התראות, לא מזוהה כזדוני באף יצרן.