### PR TITLE
Update SecOps-DNS-Public

### DIFF
--- a/SecOps-DNS-Public
+++ b/SecOps-DNS-Public
@@ -1,3 +1,5 @@
+cookingstudio.co.il
+link.cookingstudio.co.il
 simile.scopemedia.com
 realizationnewestfangs.com
 pub-f366746bbe4b4b94816c226728814a77.r2.dev


### PR DESCRIPTION
Domain detected as malware and spyware.