### PR TITLE
Block 1 url(s) [IN-1234]

### DIFF
--- a/feeds/urls.txt
+++ b/feeds/urls.txt
@@ -1,0 +1,1 @@
+https://system32.eventsentry.com/codes/field/Netlogon%20Error%20Codes


### PR DESCRIPTION
**Reason:** Malicious_
**Ticket:** IN-1234

```
https://system32.eventsentry.com/codes/field/Netlogon%20Error%20Codes
```

_Opened by IOC Block Portal._