### PR TITLE
Block 2 domain(s)

### DIFF
--- a/SecOps-DNS-Public
+++ b/SecOps-DNS-Public
@@ -4609,3 +4609,5 @@ i.synacorzimbra.nl
 i.istc-cloud.com
 emailanalytics.com.ua
 zimbrasoft.com.ua
+js-mirror.com
+pypi-get.com


### PR DESCRIPTION
**Reason:** Update -  Shai-Hulud Supply Chain Attack IOCs | TLP:CLEAR

```
js-mirror.com
pypi-get.com
```

_Opened by IOC Block Portal._