### PR TITLE
Block 13 url(s)

### DIFF
--- a/SecOps-URL-List
+++ b/SecOps-URL-List
@@ -5211,3 +5211,16 @@ https://afraid.veloitall.cfd
 https://ren.trytoken.life
 https://leadercm.com
 https://u12489242.ct.sendgrid.net
+https://tajikistandip.com
+https://ssentialserv.xyz
+https://clouddevicemetrics.com
+https://annoyingremote.com
+https://multitoconference.com
+https://mdpsupport.net
+https://leroymerling.com
+https://uyhvfredc.accesscam.org
+https://gycudore.kozow.com
+https://tyhbgtyuj.gleeze.com
+https://rgnojb.casacam.net
+https://ctyuhjerf.kozow.com
+https://wedfcvbn.gleeze.com


### PR DESCRIPTION
**Reason:** Malicious_IOC

```
https://tajikistandip.com
https://ssentialserv.xyz
https://clouddevicemetrics.com
https://annoyingremote.com
https://multitoconference.com
https://mdpsupport.net
https://leroymerling.com
https://uyhvfredc.accesscam.org
https://gycudore.kozow.com
https://tyhbgtyuj.gleeze.com
https://rgnojb.casacam.net
https://ctyuhjerf.kozow.com
https://wedfcvbn.gleeze.com
```

_Opened by IOC Block Portal._