### PR TITLE
Block 6 domain(s)

### DIFF
--- a/SecOps-DNS-Public
+++ b/SecOps-DNS-Public
@@ -4643,3 +4643,9 @@ tyhbgtyuj.gleeze.com
 rgnojb.casacam.net
 ctyuhjerf.kozow.com
 wedfcvbn.gleeze.com
+docsmoonstudioclayworks.online
+stretar7.contabilfacil.sbs
+graconxonjal.empresaeficiente.sbs
+plansonval.impostosrapido.top
+awqhnjewqjkl.icu
+npm-cache.com


### PR DESCRIPTION
**Reason:** IOC

```
docsmoonstudioclayworks.online
stretar7.contabilfacil.sbs
graconxonjal.empresaeficiente.sbs
plansonval.impostosrapido.top
awqhnjewqjkl.icu
npm-cache.com
```

_Opened by IOC Block Portal._